### PR TITLE
Fix issue in bugfix_patch context manager

### DIFF
--- a/_posts/0000-04-05-monkey-patching.md
+++ b/_posts/0000-04-05-monkey-patching.md
@@ -186,8 +186,10 @@ from contextlib import contextmanager
 def bugfix_patch():
     if _needs_patch(): # Don't forget opportunistic upgrades!
         _do_monkey_patch()
-        yield
-        _undo_monkey_patch()
+        try:
+            yield
+        finally:
+            _undo_monkey_patch()
     else:
         yield
 


### PR DESCRIPTION
Previously if some code in `affected_code()` raised an exception, the patch would not be removed